### PR TITLE
set the release tag to build date

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -12,5 +12,85 @@ jobs:
       - name: External Trigger
         if: github.ref == 'refs/heads/master'
         run: |
-          echo "**** No external release, exiting ****"
-          exit 0
+          if [ -n "${{ secrets.PAUSE_EXTERNAL_TRIGGER_BASEIMAGE_ARCH_MASTER }}" ]; then
+            echo "**** Github secret PAUSE_EXTERNAL_TRIGGER_BASEIMAGE_ARCH_MASTER is set; skipping trigger. ****"
+            exit 0
+          fi
+          echo "**** External trigger running off of master branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_BASEIMAGE_ARCH_MASTER\". ****"
+          echo "**** Retrieving external version ****"
+          EXT_RELEASE=$(echo $(date +%F))
+          if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
+            echo "**** Can't retrieve external version, exiting ****"
+            FAILURE_REASON="Can't retrieve external version for baseimage-arch branch master"
+            GHA_TRIGGER_URL="https://github.com/linuxserver/docker-baseimage-arch/actions/runs/${{ github.run_id }}"
+            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 16711680,
+              "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n**Trigger URL:** '"${GHA_TRIGGER_URL}"' \n"}],
+              "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}
+            exit 1
+          fi
+          EXT_RELEASE=$(echo ${EXT_RELEASE} | sed 's/[~,%@+;:/]//g')
+          echo "**** External version: ${EXT_RELEASE} ****"
+          echo "**** Retrieving last pushed version ****"
+          image="linuxserver/baseimage-arch"
+          tag="latest"
+          token=$(curl -sX GET \
+            "https://ghcr.io/token?scope=repository%3Alinuxserver%2Fbaseimage-arch%3Apull" \
+            | jq -r '.token')
+            multidigest=$(curl -s \
+              --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              --header "Authorization: Bearer ${token}" \
+              "https://ghcr.io/v2/${image}/manifests/${tag}" \
+              | jq -r 'first(.manifests[].digest)')
+            digest=$(curl -s \
+              --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              --header "Authorization: Bearer ${token}" \
+              "https://ghcr.io/v2/${image}/manifests/${multidigest}" \
+              | jq -r '.config.digest')
+          image_info=$(curl -sL \
+            --header "Authorization: Bearer ${token}" \
+            "https://ghcr.io/v2/${image}/blobs/${digest}")
+          if [[ $(echo $image_info | jq -r '.container_config') == "null" ]]; then
+            image_info=$(echo $image_info | jq -r '.config')
+          else
+            image_info=$(echo $image_info | jq -r '.container_config')
+          fi
+          IMAGE_RELEASE=$(echo ${image_info} | jq -r '.Labels.build_version' | awk '{print $3}')
+          IMAGE_VERSION=$(echo ${IMAGE_RELEASE} | awk -F'-ls' '{print $1}')
+          if [ -z "${IMAGE_VERSION}" ]; then
+            echo "**** Can't retrieve last pushed version, exiting ****"
+            FAILURE_REASON="Can't retrieve last pushed version for baseimage-arch tag latest"
+            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 16711680,
+              "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n"}],
+              "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}
+            exit 1
+          fi
+          echo "**** Last pushed version: ${IMAGE_VERSION} ****"
+          if [ "${EXT_RELEASE}" == "${IMAGE_VERSION}" ]; then
+            echo "**** Version ${EXT_RELEASE} already pushed, exiting ****"
+            exit 0
+          elif [ $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-baseimage-arch/job/master/lastBuild/api/json | jq -r '.building') == "true" ]; then
+            echo "**** New version ${EXT_RELEASE} found; but there already seems to be an active build on Jenkins; exiting ****"
+            exit 0
+          else
+            echo "**** New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Triggering new build ****"
+            response=$(curl -iX POST \
+              https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-baseimage-arch/job/master/buildWithParameters?PACKAGE_CHECK=false \
+              --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }} | grep -i location | sed "s|^[L|l]ocation: \(.*\)|\1|")
+            echo "**** Jenkins job queue url: ${response%$'\r'} ****"
+            echo "**** Sleeping 10 seconds until job starts ****"
+            sleep 10
+            buildurl=$(curl -s "${response%$'\r'}api/json" | jq -r '.executable.url')
+            buildurl="${buildurl%$'\r'}"
+            echo "**** Jenkins job build url: ${buildurl} ****"
+            echo "**** Attempting to change the Jenkins job description ****"
+            curl -iX POST \
+              "${buildurl}submitDescription" \
+              --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }} \
+              --data-urlencode "description=GHA external trigger https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              --data-urlencode "Submit=Submit"
+            echo "**** Notifying Discord ****"
+            TRIGGER_REASON="A version change was detected for baseimage-arch tag latest. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE}"
+            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
+              "description": "**Build Triggered** \n**Reason:** '"${TRIGGER_REASON}"' \n**Build URL:** '"${buildurl}display/redirect"' \n"}],
+              "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}
+          fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,12 +99,14 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is an os release set release type to none to indicate no external release
-    stage("Set ENV os"){
+    // If this is a custom command to determine version use that command
+    stage("Set tag custom bash"){
       steps{
         script{
-          env.EXT_RELEASE = env.PACKAGE_TAG
-          env.RELEASE_LINK = 'none'
+          env.EXT_RELEASE = sh(
+            script: ''' echo $(date +%F) ''',
+            returnStdout: true).trim()
+            env.RELEASE_LINK = 'custom_command'
         }
       }
     }
@@ -870,11 +872,11 @@ pipeline {
              "tagger": {"name": "LinuxServer Jenkins","email": "jenkins@linuxserver.io","date": "'${GITHUB_DATE}'"}}' '''
         echo "Pushing New release for Tag"
         sh '''#! /bin/bash
-              echo "Updating base packages to ${PACKAGE_TAG}" > releasebody.json
+              echo "Updating to ${EXT_RELEASE_CLEAN}" > releasebody.json
               echo '{"tag_name":"'${META_TAG}'",\
                      "target_commitish": "master",\
                      "name": "'${META_TAG}'",\
-                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n\\n**OS Changes:**\\n\\n' > start
+                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n\\n**Remote Changes:**\\n\\n' > start
               printf '","draft": false,"prerelease": false}' >> releasebody.json
               paste -d'\\0' start releasebody.json > releasebody.json.done
               curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/releases -d @releasebody.json.done'''

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,8 @@
 
 # jenkins variables
 project_name: docker-baseimage-arch
-external_type: os
+external_type: na
+custom_version_command: "echo $(date +%F)"
 release_type: stable
 release_tag: latest
 ls_branch: master


### PR DESCRIPTION
external and package triggers for master branch are disabled on github, a weekly jenkins trigger has been created: https://ci.linuxserver.io/job/External-Triggers/job/arch-baseimage/ (currently disabled)